### PR TITLE
Make webhook secret optional

### DIFF
--- a/spaceforge/cls.py
+++ b/spaceforge/cls.py
@@ -145,7 +145,7 @@ class Webhook:
 
     name_prefix: str
     endpoint: str
-    secretFromParameter: str
+    secretFromParameter: Optional[str] = optional_field
     labels: Optional[List[str]] = optional_field
 
 

--- a/spaceforge/schema.json
+++ b/spaceforge/schema.json
@@ -260,8 +260,15 @@
           "type": "string"
         },
         "secretFromParameter": {
-          "title": "Secretfromparameter",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Secretfromparameter"
         },
         "labels": {
           "anyOf": [
@@ -280,8 +287,7 @@
       },
       "required": [
         "name_prefix",
-        "endpoint",
-        "secretFromParameter"
+        "endpoint"
       ],
       "title": "Webhook",
       "type": "object"


### PR DESCRIPTION
Apparently it is not mandatory in our UI either, so let's not make it mandatory in the plugins.