### PR TITLE
Rename "runner" command into "run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ export API_KEY="your-api-key"
 export ENVIRONMENT="staging"
 
 # Test the after_plan hook
-spaceforge runner after_plan
+spaceforge run after_plan
 ```
 
 ## Available Hooks
@@ -481,13 +481,13 @@ export API_KEY="test-key"
 export TIMEOUT="60"
 
 # Test specific hook
-spaceforge runner after_plan
+spaceforge run after_plan
 
 # Test with specific plugin file
-spaceforge runner --plugin-file my_plugin.py before_apply
+spaceforge run --plugin-file my_plugin.py before_apply
 
 # Get help
-spaceforge runner --help
+spaceforge run --help
 ```
 
 ## Plugin Development Tips
@@ -531,7 +531,7 @@ def after_plan(self):
 ### 4. Testing and Debugging
 
 - Set `SPACELIFT_DEBUG=true` to enable debug logging
-- Use the runner command to test hooks during development
+- Use the `run` command to test hooks during development
 - Test with different parameter combinations
 - Validate your generated YAML before uploading to Spacelift
 
@@ -672,7 +672,7 @@ spaceforge generate security_scanner.py
 # Test locally
 export API_TOKEN="your-token"
 export SEVERITY_THRESHOLD="high"
-spaceforge runner after_plan
+spaceforge run after_plan
 ```
 
 ## Speeding up plugin execution
@@ -688,8 +688,8 @@ There are a few things you can do to speed up plugin execution.
 
 1. **Install spaceforge:** `pip install spaceforge`
 2. **Create your plugin:** Start with the quick start example
-3. **Test locally:** Use the runner command to test your hooks
-4. **Generate manifest:** Use the generate command to create plugin.yaml
+3. **Test locally:** Use the `run` command to test your hooks
+4. **Generate manifest:** Use the `generate` command to create plugin.yaml
 5. **Upload to Spacelift:** Add your plugin manifest to your Spacelift account
 
 For more advanced examples, see the [plugins](plugins/) directory in this repository.

--- a/plugins/enviroment_manager/plugin.yaml
+++ b/plugins/enviroment_manager/plugin.yaml
@@ -458,7 +458,7 @@ contexts:
       fi
 
       cd /mnt/workspace/source/$TF_VAR_spacelift_project_root
-      spaceforge runner --plugin-file /mnt/workspace/plugins/environment_manager/plugin.py before_init
+      spaceforge run --plugin-file /mnt/workspace/plugins/environment_manager/plugin.py before_init
     sensitive: false
   hooks:
     before_init:

--- a/plugins/sops/plugin.yaml
+++ b/plugins/sops/plugin.yaml
@@ -181,7 +181,7 @@ contexts:
       export PATH="/mnt/workspace/plugins/plugin_binaries:$PATH"
 
       cd /mnt/workspace/source/$TF_VAR_spacelift_project_root
-      spaceforge runner --plugin-file /mnt/workspace/plugins/sops/plugin.py before_init
+      spaceforge run --plugin-file /mnt/workspace/plugins/sops/plugin.py before_init
     sensitive: false
   hooks:
     before_init:

--- a/plugins/tflint/plugin.yaml
+++ b/plugins/tflint/plugin.yaml
@@ -323,7 +323,7 @@ contexts:
       export PATH="/mnt/workspace/plugins/plugin_binaries:$PATH"
 
       cd /mnt/workspace/source/$TF_VAR_spacelift_project_root
-      spaceforge runner --plugin-file /mnt/workspace/plugins/tflint/plugin.py before_plan
+      spaceforge run --plugin-file /mnt/workspace/plugins/tflint/plugin.py before_plan
     sensitive: false
   hooks:
     before_init:

--- a/plugins/wiz/plugin.yaml
+++ b/plugins/wiz/plugin.yaml
@@ -299,7 +299,7 @@ contexts:
       export PATH="/mnt/workspace/plugins/plugin_binaries:$PATH"
 
       cd /mnt/workspace/source/$TF_VAR_spacelift_project_root
-      spaceforge runner --plugin-file /mnt/workspace/plugins/wiz/plugin.py before_plan
+      spaceforge run --plugin-file /mnt/workspace/plugins/wiz/plugin.py before_plan
     sensitive: false
   hooks:
     before_init:

--- a/spaceforge/README.md
+++ b/spaceforge/README.md
@@ -13,7 +13,7 @@ Spaceforge provides a simple, declarative way to create Spacelift plugins by inh
 - **SpaceforgePlugin** (`plugin.py`) - Base class with hook methods and utilities
 - **PluginRunner** (`runner.py`) - Executes hook methods, loads parameters from environment
 - **PluginGenerator** (`generator.py`) - Analyzes Python plugins and generates `plugin.yaml`
-- **CLI Interface** (`__main__.py`) - Click-based CLI with `generate` and `runner` subcommands
+- **CLI Interface** (`__main__.py`) - Click-based CLI with `generate` and `run` subcommands
 - **Pydantic Dataclasses** (`cls.py`) - Type-safe data structures with validation
 
 ### Data Validation
@@ -242,10 +242,10 @@ python -m spaceforge generate my_plugin.py -o my_plugin.yaml
 export API_KEY="your-key"
 
 # Run specific hook
-python -m spaceforge runner after_plan
+python -m spaceforge run after_plan
 
 # Run with specific plugin file
-python -m spaceforge runner --plugin-file my_plugin.py before_apply
+python -m spaceforge run --plugin-file my_plugin.py before_apply
 ```
 
 ### Get Help
@@ -253,7 +253,7 @@ python -m spaceforge runner --plugin-file my_plugin.py before_apply
 ```bash
 python -m spaceforge --help
 python -m spaceforge generate --help
-python -m spaceforge runner --help
+python -m spaceforge run --help
 ```
 
 ## Generated YAML Structure
@@ -264,7 +264,7 @@ The framework automatically generates standard Spacelift plugin YAML:
 
 1. **Requirements**: If your plugin has dependencies, create a `requirements.txt` file. The generator will automatically add a `before_init` hook to install them.
 
-2. **Testing**: Use the runner command to test individual hooks during development.
+2. **Testing**: Use the `run` command to test individual hooks during development.
 
 3. **Debugging**: Set `SPACELIFT_DEBUG=true` to enable debug logging.
 

--- a/spaceforge/__main__.py
+++ b/spaceforge/__main__.py
@@ -6,7 +6,7 @@ import click
 
 from spaceforge._version import get_version
 from spaceforge.generator import generate_command
-from spaceforge.runner import runner_command
+from spaceforge.runner import run_command
 
 
 @click.group()
@@ -21,7 +21,18 @@ def cli() -> None:
 
 # Add subcommands
 cli.add_command(generate_command)
-cli.add_command(runner_command)
+cli.add_command(run_command)
+
+# KLUDGE: Add a hidden "runner" alias to the "run" command for backward compatibility.
+# It could be removed in the next major version.
+runner_alias = click.Command(
+    callback=run_command.callback,
+    help=run_command.help,
+    hidden=True,
+    name="runner",
+    params=run_command.params,
+)
+cli.add_command(runner_alias)
 
 
 def main() -> None:

--- a/spaceforge/runner.py
+++ b/spaceforge/runner.py
@@ -84,7 +84,7 @@ class PluginRunner:
 import click
 
 
-@click.command(name="runner")
+@click.command(name="run")
 @click.argument("hook_name")
 @click.option(
     "--plugin-file",
@@ -92,7 +92,7 @@ import click
     type=click.Path(exists=True, dir_okay=False, readable=True),
     help="Path to the plugin Python file (default: plugin.py)",
 )
-def runner_command(hook_name: str, plugin_file: str) -> None:
+def run_command(hook_name: str, plugin_file: str) -> None:
     """Run a specific hook method from a plugin.
 
     HOOK_NAME: Name of the hook method to execute (e.g., after_plan, before_apply)

--- a/spaceforge/templates/ensure_spaceforge_and_run.sh.j2
+++ b/spaceforge/templates/ensure_spaceforge_and_run.sh.j2
@@ -21,4 +21,4 @@ fi
 export PATH="/mnt/workspace/plugins/plugin_binaries:$PATH"
 {% endif %}
 cd /mnt/workspace/source/$TF_VAR_spacelift_project_root
-spaceforge runner --plugin-file {{plugin_file}} {{phase}}
+spaceforge run --plugin-file {{plugin_file}} {{phase}}

--- a/spaceforge/test_generator.py
+++ b/spaceforge/test_generator.py
@@ -88,7 +88,6 @@ class PluginExample(SpaceforgePlugin):
 
 
 class TestPluginGenerator:
-
     def setup_method(self) -> None:
         """Setup test fixtures."""
         self.temp_dir = tempfile.mkdtemp()
@@ -534,7 +533,7 @@ class NotAPlugin:
                 after_plan_script = mf
                 break
         assert after_plan_script is not None
-        assert "spaceforge runner" in after_plan_script.content
+        assert "spaceforge run" in after_plan_script.content
         assert "after_plan" in after_plan_script.content
 
     def test_generate_manifest(self) -> None:

--- a/spaceforge/test_runner.py
+++ b/spaceforge/test_runner.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from spaceforge.plugin import SpaceforgePlugin
-from spaceforge.runner import PluginRunner, runner_command
+from spaceforge.runner import PluginRunner, run_command
 
 
 class PluginForTesting(SpaceforgePlugin):
@@ -41,7 +41,6 @@ class PluginForTesting(SpaceforgePlugin):
 
 
 class TestPluginRunner:
-
     def setup_method(self) -> None:
         """Setup test fixtures."""
         self.temp_dir = tempfile.mkdtemp()
@@ -293,7 +292,7 @@ class ClickTestPlugin(SpaceforgePlugin):
 
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_runner_command(self) -> None:
+    def test_run_command(self) -> None:
         """Test the Click runner command."""
         from click.testing import CliRunner
 
@@ -305,7 +304,7 @@ class ClickTestPlugin(SpaceforgePlugin):
 
             # Test the command using Click's test runner
             result = cli_runner.invoke(
-                runner_command, ["after_plan", "--plugin-file", self.test_plugin_path]
+                run_command, ["after_plan", "--plugin-file", self.test_plugin_path]
             )
 
             assert result.exit_code == 0
@@ -316,7 +315,7 @@ class ClickTestPlugin(SpaceforgePlugin):
             # Verify run_hook was called with correct hook name
             mock_runner.run_hook.assert_called_once_with("after_plan")
 
-    def test_runner_command_default_plugin_file(self) -> None:
+    def test_run_command_default_plugin_file(self) -> None:
         """Test runner command with default plugin file."""
         from click.testing import CliRunner
 
@@ -328,7 +327,7 @@ class ClickTestPlugin(SpaceforgePlugin):
 
             # Test with explicit plugin file path
             result = cli_runner.invoke(
-                runner_command, ["before_apply", "--plugin-file", self.test_plugin_path]
+                run_command, ["before_apply", "--plugin-file", self.test_plugin_path]
             )
 
             assert result.exit_code == 0

--- a/spaceforge/test_runner_cli.py
+++ b/spaceforge/test_runner_cli.py
@@ -3,7 +3,7 @@
 import os
 from unittest.mock import Mock, patch
 
-from spaceforge.runner import runner_command
+from spaceforge.runner import run_command
 
 
 class TestRunnerClickCommand:
@@ -34,7 +34,7 @@ class ClickTestPlugin(SpaceforgePlugin):
             mock_runner_class.return_value = mock_runner
 
             result = cli_runner.invoke(
-                runner_command, ["after_plan", "--plugin-file", click_plugin_path]
+                run_command, ["after_plan", "--plugin-file", click_plugin_path]
             )
 
         # Assert
@@ -60,7 +60,7 @@ class ClickTestPlugin(SpaceforgePlugin):
             mock_runner_class.return_value = mock_runner
 
             result = cli_runner.invoke(
-                runner_command, ["before_apply", "--plugin-file", custom_plugin_path]
+                run_command, ["before_apply", "--plugin-file", custom_plugin_path]
             )
 
         # Assert


### PR DESCRIPTION
I added a hidden "runner" alias to avoid breaking deployed plugins.