### PR TITLE
feat: Move Wiz scan to after_plan with plan file export and auto-naming

### DIFF
--- a/plugins/wiz/plugin.py
+++ b/plugins/wiz/plugin.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 
 from spaceforge import Binary, Context, Parameter, Policy, SpaceforgePlugin, Variable
 
@@ -9,6 +10,9 @@ class WizPlugin(SpaceforgePlugin):
     This adds the `wiz` plugin to your Spacelift account.
     It will scan your infrastructure as code (IaC) for vulnerabilities using Wiz CLI, generating a report of findings and
     adding them to the policy input.
+
+    The scan runs after the plan phase, so it includes resolved Terraform modules and the exported plan file
+    in the directory scan for broader coverage.
 
     ## Usage
 
@@ -23,7 +27,7 @@ class WizPlugin(SpaceforgePlugin):
     # Plugin metadata
     __plugin_name__ = "Wiz"
     __labels__ = ["security", "code scanning", "vulnerability"]
-    __version__ = "2.1.0"
+    __version__ = "3.0.0"
     __author__ = "Spacelift Team"
 
     __binaries__ = [
@@ -41,7 +45,7 @@ class WizPlugin(SpaceforgePlugin):
         Parameter(
             name="Default Scan Name",
             id="default_scan_name",
-            description="The default name of the scan that shows up in wiz. This setting can be overridden on individual stacks by manually setting the environment variable (DEFAULT_SCAN_NAME) there",
+            description="The name of the scan that shows up in Wiz. If left empty, defaults to '{stack_id}-{run_id}'. This setting can be overridden on individual stacks by manually setting the environment variable (DEFAULT_SCAN_NAME) there",
             default="",
             type="string",
             required=False,
@@ -199,14 +203,77 @@ deny[sprintf("Too many low vulnerabilities (%d)", [num])] {
     def __init__(self):
         super().__init__()
 
-    def before_plan(self):
-        self.logger.info("Checking IAC Code")
+    def _get_iac_binary(self):
+        """Detect whether tofu or terraform is available."""
+        for binary in ["tofu", "terraform"]:
+            if shutil.which(binary):
+                return binary
+        return None
+
+    def _export_plan_json(self):
+        """Export the Spacelift plan file to JSON so wizcli can scan it."""
+        plan_file = "spacelift.plan"
+        plan_json = "spacelift_plan.json"
+
+        if not os.path.exists(plan_file):
+            self.logger.warning(
+                f"Plan file '{plan_file}' not found, skipping plan export"
+            )
+            return False
+
+        iac_binary = self._get_iac_binary()
+        if iac_binary is None:
+            self.logger.warning(
+                "Neither tofu nor terraform found in PATH, skipping plan export"
+            )
+            return False
+
+        self.logger.info(f"Exporting plan file using {iac_binary}")
+        return_code, stdout, stderr = self.run_cli(
+            iac_binary, "show", "-no-color", "-json", plan_file, print_output=False
+        )
+
+        if return_code != 0:
+            self.logger.warning(
+                f"Failed to export plan JSON (exit code {return_code}), "
+                "continuing with directory scan only"
+            )
+            return False
+
+        with open(plan_json, "w") as f:
+            f.write("\n".join(stdout))
+
+        self.logger.info(f"Plan exported to {plan_json}")
+        return True
+
+    def _get_scan_name(self):
+        """Get scan name from env var or auto-generate from stack/run IDs."""
+        custom_name = os.environ.get("DEFAULT_SCAN_NAME", "").strip()
+        if custom_name:
+            return custom_name
+
+        stack_id = os.environ.get("TF_VAR_spacelift_stack_id", "")
+        run_id = os.environ.get("TF_VAR_spacelift_run_id", "")
+
+        if stack_id and run_id:
+            return f"{stack_id}-{run_id}"
+
+        if stack_id:
+            return stack_id
+
+        return None
+
+    def after_plan(self):
+        self.logger.info("Scanning IaC after plan")
 
         if os.environ.get("IS_GOVCLOUD", "false").lower() == "true":
             os.environ["WIZ_ENV"] = "gov"
 
         if os.environ.get("IS_FEDRAMP", "false").lower() == "true":
             os.environ["WIZ_ENV"] = "fedramp"
+
+        # Export plan file to JSON so wizcli includes it in the directory scan
+        self._export_plan_json()
 
         args = [
             "wizcli",
@@ -219,10 +286,12 @@ deny[sprintf("Too many low vulnerabilities (%d)", [num])] {
             "--no-color",
             "--no-telemetry",
             "--no-browser",
+            "--discovered-resources",
         ]
 
-        if os.environ.get("DEFAULT_SCAN_NAME", "") != "":
-            args.extend(["--name", os.environ.get("DEFAULT_SCAN_NAME")])
+        scan_name = self._get_scan_name()
+        if scan_name:
+            args.extend(["--name", scan_name])
 
         if os.environ.get("DEFAULT_POLICIES", "") != "":
             policies = os.environ.get("DEFAULT_POLICIES").split(",")

--- a/plugins/wiz/plugin.yaml
+++ b/plugins/wiz/plugin.yaml
@@ -1,9 +1,12 @@
 name: Wiz
-version: 2.1.0
+version: 3.0.0
 description: |-
   This adds the `wiz` plugin to your Spacelift account.
   It will scan your infrastructure as code (IaC) for vulnerabilities using Wiz CLI, generating a report of findings and
   adding them to the policy input.
+
+  The scan runs after the plan phase, so it includes resolved Terraform modules and the exported plan file
+  in the directory scan for broader coverage.
 
   ## Usage
 
@@ -20,7 +23,7 @@ labels:
 - vulnerability
 parameters:
 - name: Default Scan Name
-  description: The default name of the scan that shows up in wiz. This setting can be overridden on individual stacks by manually setting the environment variable (DEFAULT_SCAN_NAME) there
+  description: The name of the scan that shows up in Wiz. If left empty, defaults to '{stack_id}-{run_id}'. This setting can be overridden on individual stacks by manually setting the environment variable (DEFAULT_SCAN_NAME) there
   type: string
   sensitive: false
   required: false
@@ -106,6 +109,7 @@ contexts:
     content: |-
       import json
       import os
+      import shutil
 
       from spaceforge import Binary, Context, Parameter, Policy, SpaceforgePlugin, Variable
 
@@ -115,6 +119,9 @@ contexts:
           This adds the `wiz` plugin to your Spacelift account.
           It will scan your infrastructure as code (IaC) for vulnerabilities using Wiz CLI, generating a report of findings and
           adding them to the policy input.
+
+          The scan runs after the plan phase, so it includes resolved Terraform modules and the exported plan file
+          in the directory scan for broader coverage.
 
           ## Usage
 
@@ -129,7 +136,7 @@ contexts:
           # Plugin metadata
           __plugin_name__ = "Wiz"
           __labels__ = ["security", "code scanning", "vulnerability"]
-          __version__ = "2.1.0"
+          __version__ = "3.0.0"
           __author__ = "Spacelift Team"
 
           __binaries__ = [
@@ -147,7 +154,7 @@ contexts:
               Parameter(
                   name="Default Scan Name",
                   id="default_scan_name",
-                  description="The default name of the scan that shows up in wiz. This setting can be overridden on individual stacks by manually setting the environment variable (DEFAULT_SCAN_NAME) there",
+                  description="The name of the scan that shows up in Wiz. If left empty, defaults to '{stack_id}-{run_id}'. This setting can be overridden on individual stacks by manually setting the environment variable (DEFAULT_SCAN_NAME) there",
                   default="",
                   type="string",
                   required=False,
@@ -305,14 +312,77 @@ contexts:
           def __init__(self):
               super().__init__()
 
-          def before_plan(self):
-              self.logger.info("Checking IAC Code")
+          def _get_iac_binary(self):
+              """Detect whether tofu or terraform is available."""
+              for binary in ["tofu", "terraform"]:
+                  if shutil.which(binary):
+                      return binary
+              return None
+
+          def _export_plan_json(self):
+              """Export the Spacelift plan file to JSON so wizcli can scan it."""
+              plan_file = "spacelift.plan"
+              plan_json = "spacelift_plan.json"
+
+              if not os.path.exists(plan_file):
+                  self.logger.warning(
+                      f"Plan file '{plan_file}' not found, skipping plan export"
+                  )
+                  return False
+
+              iac_binary = self._get_iac_binary()
+              if iac_binary is None:
+                  self.logger.warning(
+                      "Neither tofu nor terraform found in PATH, skipping plan export"
+                  )
+                  return False
+
+              self.logger.info(f"Exporting plan file using {iac_binary}")
+              return_code, stdout, stderr = self.run_cli(
+                  iac_binary, "show", "-no-color", "-json", plan_file, print_output=False
+              )
+
+              if return_code != 0:
+                  self.logger.warning(
+                      f"Failed to export plan JSON (exit code {return_code}), "
+                      "continuing with directory scan only"
+                  )
+                  return False
+
+              with open(plan_json, "w") as f:
+                  f.write("\n".join(stdout))
+
+              self.logger.info(f"Plan exported to {plan_json}")
+              return True
+
+          def _get_scan_name(self):
+              """Get scan name from env var or auto-generate from stack/run IDs."""
+              custom_name = os.environ.get("DEFAULT_SCAN_NAME", "").strip()
+              if custom_name:
+                  return custom_name
+
+              stack_id = os.environ.get("TF_VAR_spacelift_stack_id", "")
+              run_id = os.environ.get("TF_VAR_spacelift_run_id", "")
+
+              if stack_id and run_id:
+                  return f"{stack_id}-{run_id}"
+
+              if stack_id:
+                  return stack_id
+
+              return None
+
+          def after_plan(self):
+              self.logger.info("Scanning IaC after plan")
 
               if os.environ.get("IS_GOVCLOUD", "false").lower() == "true":
                   os.environ["WIZ_ENV"] = "gov"
 
               if os.environ.get("IS_FEDRAMP", "false").lower() == "true":
                   os.environ["WIZ_ENV"] = "fedramp"
+
+              # Export plan file to JSON so wizcli includes it in the directory scan
+              self._export_plan_json()
 
               args = [
                   "wizcli",
@@ -325,10 +395,12 @@ contexts:
                   "--no-color",
                   "--no-telemetry",
                   "--no-browser",
+                  "--discovered-resources",
               ]
 
-              if os.environ.get("DEFAULT_SCAN_NAME", "") != "":
-                  args.extend(["--name", os.environ.get("DEFAULT_SCAN_NAME")])
+              scan_name = self._get_scan_name()
+              if scan_name:
+                  args.extend(["--name", scan_name])
 
               if os.environ.get("DEFAULT_POLICIES", "") != "":
                   policies = os.environ.get("DEFAULT_POLICIES").split(",")
@@ -483,7 +555,7 @@ contexts:
 
       chmod +x "/mnt/workspace/plugins/plugin_binaries/wizcli"
     sensitive: false
-  - path: /mnt/workspace/plugins/wiz/before_plan.sh
+  - path: /mnt/workspace/plugins/wiz/after_plan.sh
     content: |-
       #!/bin/sh
 
@@ -508,14 +580,14 @@ contexts:
       export PATH="/mnt/workspace/plugins/plugin_binaries:$PATH"
 
       cd /mnt/workspace/source/$TF_VAR_spacelift_project_root
-      python -m spaceforge run --plugin-file /mnt/workspace/plugins/wiz/plugin.py before_plan
+      python -m spaceforge run --plugin-file /mnt/workspace/plugins/wiz/plugin.py after_plan
     sensitive: false
   hooks:
     before_init:
     - mkdir -p /mnt/workspace/plugins/wiz
     - chmod +x /mnt/workspace/plugins/wiz/binary_install_wizcli.sh && /mnt/workspace/plugins/wiz/binary_install_wizcli.sh
-    before_plan:
-    - chmod +x /mnt/workspace/plugins/wiz/before_plan.sh && /mnt/workspace/plugins/wiz/before_plan.sh
+    after_plan:
+    - chmod +x /mnt/workspace/plugins/wiz/after_plan.sh && /mnt/workspace/plugins/wiz/after_plan.sh
 policies:
 - name_prefix: wiz_policy
   type: PLAN


### PR DESCRIPTION
## Summary

Updates the Wiz plugin from v2.1.0 to v3.0.0, moving the IaC scan from `before_plan` to `after_plan`. This enables scanning of resolved Terraform modules and the exported plan file, providing broader security coverage. Also adds auto-generated scan names and the `--discovered-resources` flag.

**Context:** Customer request from Equity Residential (#equityresidential-spacelift) — they were previously scanning plan files with wizcli v0 (`wizcli iac scan --path $PATH_TO_PLAN`) which is not available in v1. This approach exports the plan as JSON into the source directory so `wizcli scan dir` picks it up alongside the IaC source files.

## Changes

### 1. Scan timing: `before_plan` → `after_plan`

The scan now runs after Terraform/OpenTofu generates a plan. This means:
- Resolved modules in `.terraform/` are included in the scan
- The exported plan JSON is present in the directory for wizcli to analyze

### 2. Plan file export

New `_export_plan_json()` method runs `{tofu|terraform} show -no-color -json spacelift.plan > spacelift_plan.json` before the scan. Auto-detects whether `tofu` or `terraform` is available. Gracefully degrades — if the plan file doesn't exist or the binary isn't found, the scan continues against the directory alone.

### 3. Auto-generated scan names

New `_get_scan_name()` method generates `{stack_id}-{run_id}` as the default scan name when no custom `DEFAULT_SCAN_NAME` is set. This matches the naming convention the customer was already using manually. Custom names still take priority.

### 4. `--discovered-resources` flag

Added as a default flag on all scans. This wizcli v1 feature discovers the actual cloud resources Terraform would create and includes them in the scan output.

### 5. Version bump to 3.0.0

Major version bump since moving the scan from `before_plan` to `after_plan` is a behavioral change for existing users.

## Verified
 
- `black` formatting passes
- `validate_plugins.py` passes for wiz plugin
- `spaceforge generate plugin.py` regenerates plugin.yaml cleanly
- wizcli v1 auth confirmed working with test service account (exit code 0, verdict `PASSED_BY_POLICY`)
 
## Needs integration testing (on a real Spacelift stack)
 
- Scan name auto-generation shows `{stack_id}-{run_id}` in Wiz dashboard
- Plan file export works with both `tofu` and `terraform` runners
- Graceful degradation when `spacelift.plan` doesn't exist (e.g. on a task run)
- `--discovered-resources` output appears in scan results