### PR TITLE
fix: handle wiz-cli specific exit codes instead of generic failure

### DIFF
--- a/plugins/wiz/plugin.py
+++ b/plugins/wiz/plugin.py
@@ -312,76 +312,83 @@ deny[sprintf("Too many low vulnerabilities (%d)", [num])] {
                 self.logger.error(line)
             exit(1)
 
-        if return_code != 0:
-            self.logger.error("Wiz CLI scan failed")
-            self.logger.debug(f"exit: {return_code}", stdout, stderr)
-        else:
+        if return_code == 1:
+            self.logger.error(
+                "Wiz CLI Error: General error (timeout, network interruption, etc.)"
+            )
+            exit(1)
 
-            with open("wiz_scan.json", "r") as f:
-                results = json.load(f)
+        if return_code == 2:
+            self.logger.error("Wiz CLI Error: Invalid command-line arguments")
+            exit(1)
 
+        if return_code == 3:
+            self.logger.error("Wiz CLI Error: Authentication issue.")
+            exit(1)
+
+        with open("wiz_scan.json", "r") as f:
+            results = json.load(f)
+
+        self.logger.debug(results)
+
+        if results is None:
+            self.logger.error("Failed to parse Wiz CLI output as JSON")
+            self.logger.debug(stdout, results)
+            exit(1)
+
+        if "result" not in results or "ruleMatches" not in results["result"]:
+            self.logger.error("Unexpected Wiz CLI output format")
             self.logger.debug(results)
+            exit(1)
 
-            if results is None:
-                self.logger.error("Failed to parse Wiz CLI output as JSON")
-                self.logger.debug(stdout, results)
-                exit(1)
+        self.add_to_policy_input("wiz", results)
 
-            if "result" not in results or "ruleMatches" not in results["result"]:
-                self.logger.error("Unexpected Wiz CLI output format")
-                self.logger.debug(results)
-                exit(1)
+        if results["result"]["ruleMatches"] is None:
+            self.logger.info("No findings found in the IAC scan.")
+        else:
+            findings = {}
+            # Sort the findings by the severity and their rule id
+            for match in results["result"]["ruleMatches"]:
+                if match["severity"] not in findings:
+                    findings[match["severity"]] = {}
+                if match["rule"]["id"] not in findings[match["severity"]]:
+                    findings[match["severity"]][match["rule"]["id"]] = {
+                        "rule": match["rule"],
+                        "matches": [],
+                    }
+                findings[match["severity"]][match["rule"]["id"]]["matches"].append(
+                    match
+                )
 
-            self.add_to_policy_input("wiz", results)
+            markdown = "# Wiz IAC Scan Findings\n\n"
+            markdown += f"**Status:** {results['status']['state']} **Verdict:** {results['status']['verdict']}\n"
+            for severity, matches in findings.items():
+                severity = severity.upper()
 
-            if results["result"]["ruleMatches"] is None:
-                self.logger.info("No findings found in the IAC scan.")
-            else:
-                findings = {}
-                # Sort the findings by the severity and their rule id
-                for match in results["result"]["ruleMatches"]:
-                    if match["severity"] not in findings:
-                        findings[match["severity"]] = {}
-                    if match["rule"]["id"] not in findings[match["severity"]]:
-                        findings[match["severity"]][match["rule"]["id"]] = {
-                            "rule": match["rule"],
-                            "matches": [],
-                        }
-                    findings[match["severity"]][match["rule"]["id"]]["matches"].append(
-                        match
-                    )
+                emoji = None
+                if severity == "INFORMATIONAL":
+                    emoji = "🟢"
+                if severity == "LOW":
+                    emoji = "🟡"
+                elif severity == "MEDIUM":
+                    emoji = "🟡"
+                elif severity == "HIGH":
+                    emoji = "🟠"
+                elif severity == "CRITICAL":
+                    emoji = "🔴"
+                if emoji is not None:
+                    markdown += f"### {emoji} {severity} Findings\n"
+                else:
+                    markdown += f"### {severity} Findings\n"
 
-                markdown = "# Wiz IAC Scan Findings\n\n"
-                markdown += f"**Status:** {results['status']['state']} **Verdict:** {results['status']['verdict']}\n"
-                for severity, matches in findings.items():
-                    severity = severity.upper()
-
-                    emoji = None
-                    if severity == "INFORMATIONAL":
-                        emoji = "🟢"
-                    if severity == "LOW":
-                        emoji = "🟡"
-                    elif severity == "MEDIUM":
-                        emoji = "🟡"
-                    elif severity == "HIGH":
-                        emoji = "🟠"
-                    elif severity == "CRITICAL":
-                        emoji = "🔴"
-                    if emoji is not None:
-                        markdown += f"### {emoji} {severity} Findings\n"
-                    else:
-                        markdown += f"### {severity} Findings\n"
-
-                    for rule_id, rule_data in matches.items():
-                        markdown += (
-                            f"#### {rule_data['rule']['name']} (ID: {rule_id})\n"
-                        )
-                        for cycled_rule in rule_data["matches"]:
-                            for match in cycled_rule["matches"]:
-                                markdown += f"- File: {match['fileName']}, Line: {match['lineNumber']}\n"
-                        markdown += "\n"
-                if "reportUrl" in results:
-                    markdown += f"[View Report]({results['reportUrl']})\n"
-                result = self.send_markdown(markdown)
-                if not result:
-                    self.logger.error("Failed to send Wiz CLI output to spacelift")
+                for rule_id, rule_data in matches.items():
+                    markdown += f"#### {rule_data['rule']['name']} (ID: {rule_id})\n"
+                    for cycled_rule in rule_data["matches"]:
+                        for match in cycled_rule["matches"]:
+                            markdown += f"- File: {match['fileName']}, Line: {match['lineNumber']}\n"
+                    markdown += "\n"
+            if "reportUrl" in results:
+                markdown += f"[View Report]({results['reportUrl']})\n"
+            result = self.send_markdown(markdown)
+            if not result:
+                self.logger.error("Failed to send Wiz CLI output to spacelift")

--- a/plugins/wiz/plugin.yaml
+++ b/plugins/wiz/plugin.yaml
@@ -421,79 +421,86 @@ contexts:
                       self.logger.error(line)
                   exit(1)
 
-              if return_code != 0:
-                  self.logger.error("Wiz CLI scan failed")
-                  self.logger.debug(f"exit: {return_code}", stdout, stderr)
-              else:
+              if return_code == 1:
+                  self.logger.error(
+                      "Wiz CLI Error: General error (timeout, network interruption, etc.)"
+                  )
+                  exit(1)
 
-                  with open("wiz_scan.json", "r") as f:
-                      results = json.load(f)
+              if return_code == 2:
+                  self.logger.error("Wiz CLI Error: Invalid command-line arguments")
+                  exit(1)
 
+              if return_code == 3:
+                  self.logger.error("Wiz CLI Error: Authentication issue.")
+                  exit(1)
+
+              with open("wiz_scan.json", "r") as f:
+                  results = json.load(f)
+
+              self.logger.debug(results)
+
+              if results is None:
+                  self.logger.error("Failed to parse Wiz CLI output as JSON")
+                  self.logger.debug(stdout, results)
+                  exit(1)
+
+              if "result" not in results or "ruleMatches" not in results["result"]:
+                  self.logger.error("Unexpected Wiz CLI output format")
                   self.logger.debug(results)
+                  exit(1)
 
-                  if results is None:
-                      self.logger.error("Failed to parse Wiz CLI output as JSON")
-                      self.logger.debug(stdout, results)
-                      exit(1)
+              self.add_to_policy_input("wiz", results)
 
-                  if "result" not in results or "ruleMatches" not in results["result"]:
-                      self.logger.error("Unexpected Wiz CLI output format")
-                      self.logger.debug(results)
-                      exit(1)
+              if results["result"]["ruleMatches"] is None:
+                  self.logger.info("No findings found in the IAC scan.")
+              else:
+                  findings = {}
+                  # Sort the findings by the severity and their rule id
+                  for match in results["result"]["ruleMatches"]:
+                      if match["severity"] not in findings:
+                          findings[match["severity"]] = {}
+                      if match["rule"]["id"] not in findings[match["severity"]]:
+                          findings[match["severity"]][match["rule"]["id"]] = {
+                              "rule": match["rule"],
+                              "matches": [],
+                          }
+                      findings[match["severity"]][match["rule"]["id"]]["matches"].append(
+                          match
+                      )
 
-                  self.add_to_policy_input("wiz", results)
+                  markdown = "# Wiz IAC Scan Findings\n\n"
+                  markdown += f"**Status:** {results['status']['state']} **Verdict:** {results['status']['verdict']}\n"
+                  for severity, matches in findings.items():
+                      severity = severity.upper()
 
-                  if results["result"]["ruleMatches"] is None:
-                      self.logger.info("No findings found in the IAC scan.")
-                  else:
-                      findings = {}
-                      # Sort the findings by the severity and their rule id
-                      for match in results["result"]["ruleMatches"]:
-                          if match["severity"] not in findings:
-                              findings[match["severity"]] = {}
-                          if match["rule"]["id"] not in findings[match["severity"]]:
-                              findings[match["severity"]][match["rule"]["id"]] = {
-                                  "rule": match["rule"],
-                                  "matches": [],
-                              }
-                          findings[match["severity"]][match["rule"]["id"]]["matches"].append(
-                              match
-                          )
+                      emoji = None
+                      if severity == "INFORMATIONAL":
+                          emoji = "🟢"
+                      if severity == "LOW":
+                          emoji = "🟡"
+                      elif severity == "MEDIUM":
+                          emoji = "🟡"
+                      elif severity == "HIGH":
+                          emoji = "🟠"
+                      elif severity == "CRITICAL":
+                          emoji = "🔴"
+                      if emoji is not None:
+                          markdown += f"### {emoji} {severity} Findings\n"
+                      else:
+                          markdown += f"### {severity} Findings\n"
 
-                      markdown = "# Wiz IAC Scan Findings\n\n"
-                      markdown += f"**Status:** {results['status']['state']} **Verdict:** {results['status']['verdict']}\n"
-                      for severity, matches in findings.items():
-                          severity = severity.upper()
-
-                          emoji = None
-                          if severity == "INFORMATIONAL":
-                              emoji = "🟢"
-                          if severity == "LOW":
-                              emoji = "🟡"
-                          elif severity == "MEDIUM":
-                              emoji = "🟡"
-                          elif severity == "HIGH":
-                              emoji = "🟠"
-                          elif severity == "CRITICAL":
-                              emoji = "🔴"
-                          if emoji is not None:
-                              markdown += f"### {emoji} {severity} Findings\n"
-                          else:
-                              markdown += f"### {severity} Findings\n"
-
-                          for rule_id, rule_data in matches.items():
-                              markdown += (
-                                  f"#### {rule_data['rule']['name']} (ID: {rule_id})\n"
-                              )
-                              for cycled_rule in rule_data["matches"]:
-                                  for match in cycled_rule["matches"]:
-                                      markdown += f"- File: {match['fileName']}, Line: {match['lineNumber']}\n"
-                              markdown += "\n"
-                      if "reportUrl" in results:
-                          markdown += f"[View Report]({results['reportUrl']})\n"
-                      result = self.send_markdown(markdown)
-                      if not result:
-                          self.logger.error("Failed to send Wiz CLI output to spacelift")
+                      for rule_id, rule_data in matches.items():
+                          markdown += f"#### {rule_data['rule']['name']} (ID: {rule_id})\n"
+                          for cycled_rule in rule_data["matches"]:
+                              for match in cycled_rule["matches"]:
+                                  markdown += f"- File: {match['fileName']}, Line: {match['lineNumber']}\n"
+                          markdown += "\n"
+                  if "reportUrl" in results:
+                      markdown += f"[View Report]({results['reportUrl']})\n"
+                  result = self.send_markdown(markdown)
+                  if not result:
+                      self.logger.error("Failed to send Wiz CLI output to spacelift")
     sensitive: false
   - path: /mnt/workspace/plugins/wiz/binary_install_wizcli.sh
     content: |-


### PR DESCRIPTION
## Summary

- Replace generic `return_code != 0` error handling with specific exit code checks for wiz-cli
- Exit codes 1 (general error), 2 (invalid args), and 3 (auth issue) now produce descriptive error messages and halt execution
- Exit code 4 (policy violations found) now falls through to process results instead of failing

## Changes

The previous implementation treated all non-zero exit codes as fatal errors, which was incorrect. Wiz CLI uses exit code 4 to indicate that the scan completed successfully but policy violations were found. This is not an error — it's the expected path for reporting findings.

1. **`plugins/wiz/plugin.py`**: Replaced the `if return_code != 0` block with individual checks for exit codes 1, 2, and 3 with descriptive error messages. The result-processing logic is no longer nested inside an `else` block, allowing exit code 4 (and 0) to flow through to JSON parsing and findings reporting.

2. **`plugins/wiz/plugin.yaml`**: Regenerated plugin YAML to reflect the updated plugin code.