### PR TITLE
fix: add curl retry flags to binary install template

### DIFF
--- a/plugins/envsubst/plugin.yaml
+++ b/plugins/envsubst/plugin.yaml
@@ -122,7 +122,8 @@ contexts:
               trap 'rm -rf "$TMP_DIR"' EXIT
 
               ARCHIVE="$TMP_DIR/archive"
-              curl "$URL" -o "$ARCHIVE" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "$ARCHIVE"
 
               case "$URL" in
                   *.tar.gz)
@@ -145,7 +146,8 @@ contexts:
               mv "$FOUND_BINARY" "/mnt/workspace/plugins/plugin_binaries/envsubst"
               ;;
           *)
-              curl "$URL" -o "/mnt/workspace/plugins/plugin_binaries/envsubst" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "/mnt/workspace/plugins/plugin_binaries/envsubst"
               ;;
       esac
 

--- a/plugins/opentofu-tracing/plugin.yaml
+++ b/plugins/opentofu-tracing/plugin.yaml
@@ -577,7 +577,8 @@ contexts:
               trap 'rm -rf "$TMP_DIR"' EXIT
 
               ARCHIVE="$TMP_DIR/archive"
-              curl "$URL" -o "$ARCHIVE" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "$ARCHIVE"
 
               case "$URL" in
                   *.tar.gz)
@@ -600,7 +601,8 @@ contexts:
               mv "$FOUND_BINARY" "/mnt/workspace/plugins/plugin_binaries/tracedown"
               ;;
           *)
-              curl "$URL" -o "/mnt/workspace/plugins/plugin_binaries/tracedown" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "/mnt/workspace/plugins/plugin_binaries/tracedown"
               ;;
       esac
 

--- a/plugins/sops/plugin.yaml
+++ b/plugins/sops/plugin.yaml
@@ -231,7 +231,8 @@ contexts:
               trap 'rm -rf "$TMP_DIR"' EXIT
 
               ARCHIVE="$TMP_DIR/archive"
-              curl "$URL" -o "$ARCHIVE" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "$ARCHIVE"
 
               case "$URL" in
                   *.tar.gz)
@@ -254,7 +255,8 @@ contexts:
               mv "$FOUND_BINARY" "/mnt/workspace/plugins/plugin_binaries/sops"
               ;;
           *)
-              curl "$URL" -o "/mnt/workspace/plugins/plugin_binaries/sops" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "/mnt/workspace/plugins/plugin_binaries/sops"
               ;;
       esac
 

--- a/plugins/terrascan/plugin.yaml
+++ b/plugins/terrascan/plugin.yaml
@@ -390,7 +390,8 @@ contexts:
               trap 'rm -rf "$TMP_DIR"' EXIT
 
               ARCHIVE="$TMP_DIR/archive"
-              curl "$URL" -o "$ARCHIVE" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "$ARCHIVE"
 
               case "$URL" in
                   *.tar.gz)
@@ -413,7 +414,8 @@ contexts:
               mv "$FOUND_BINARY" "/mnt/workspace/plugins/plugin_binaries/terrascan"
               ;;
           *)
-              curl "$URL" -o "/mnt/workspace/plugins/plugin_binaries/terrascan" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "/mnt/workspace/plugins/plugin_binaries/terrascan"
               ;;
       esac
 

--- a/plugins/trivy/plugin.yaml
+++ b/plugins/trivy/plugin.yaml
@@ -299,7 +299,8 @@ contexts:
               trap 'rm -rf "$TMP_DIR"' EXIT
 
               ARCHIVE="$TMP_DIR/archive"
-              curl "$URL" -o "$ARCHIVE" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "$ARCHIVE"
 
               case "$URL" in
                   *.tar.gz)
@@ -322,7 +323,8 @@ contexts:
               mv "$FOUND_BINARY" "/mnt/workspace/plugins/plugin_binaries/trivy"
               ;;
           *)
-              curl "$URL" -o "/mnt/workspace/plugins/plugin_binaries/trivy" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "/mnt/workspace/plugins/plugin_binaries/trivy"
               ;;
       esac
 

--- a/plugins/trufflehog/plugin.yaml
+++ b/plugins/trufflehog/plugin.yaml
@@ -390,7 +390,8 @@ contexts:
               trap 'rm -rf "$TMP_DIR"' EXIT
 
               ARCHIVE="$TMP_DIR/archive"
-              curl "$URL" -o "$ARCHIVE" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "$ARCHIVE"
 
               case "$URL" in
                   *.tar.gz)
@@ -413,7 +414,8 @@ contexts:
               mv "$FOUND_BINARY" "/mnt/workspace/plugins/plugin_binaries/trufflehog"
               ;;
           *)
-              curl "$URL" -o "/mnt/workspace/plugins/plugin_binaries/trufflehog" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "/mnt/workspace/plugins/plugin_binaries/trufflehog"
               ;;
       esac
 

--- a/plugins/wiz/plugin.yaml
+++ b/plugins/wiz/plugin.yaml
@@ -533,7 +533,8 @@ contexts:
               trap 'rm -rf "$TMP_DIR"' EXIT
 
               ARCHIVE="$TMP_DIR/archive"
-              curl "$URL" -o "$ARCHIVE" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "$ARCHIVE"
 
               case "$URL" in
                   *.tar.gz)
@@ -556,7 +557,8 @@ contexts:
               mv "$FOUND_BINARY" "/mnt/workspace/plugins/plugin_binaries/wizcli"
               ;;
           *)
-              curl "$URL" -o "/mnt/workspace/plugins/plugin_binaries/wizcli" -fL
+              curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+                   -fL "$URL" -o "/mnt/workspace/plugins/plugin_binaries/wizcli"
               ;;
       esac
 

--- a/spaceforge/templates/binary_install.sh.j2
+++ b/spaceforge/templates/binary_install.sh.j2
@@ -27,7 +27,8 @@ case "$URL" in
         trap 'rm -rf "$TMP_DIR"' EXIT
         
         ARCHIVE="$TMP_DIR/archive"
-        curl "$URL" -o "$ARCHIVE" -fL
+        curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+             -fL "$URL" -o "$ARCHIVE"
 
         case "$URL" in
             *.tar.gz)
@@ -50,7 +51,8 @@ case "$URL" in
         mv "$FOUND_BINARY" "{{binary_path}}"
         ;;
     *)
-        curl "$URL" -o "{{binary_path}}" -fL
+        curl --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 10 \
+             -fL "$URL" -o "{{binary_path}}"
         ;;
 esac
 


### PR DESCRIPTION
Spacelift workspace initialization fails intermittently when a plugin downloads its binary from GitHub releases:

```
Installing trivy...
curl: (35) Send failure: Connection reset by peer
Unexpected exit code when initializing workspace: 35
```

A single transient TCP reset kills the run immediately. For stacks that run on every PR, this creates false-positive check failures that require a manual retry.

Both `curl` invocations in `spaceforge/templates/binary_install.sh.j2` lack retry flags.

```sh
curl "$URL" -o "$ARCHIVE" -fL
```

The template generates the install script for **every** plugin that declares a `Binary()` — trivy, sops, terrascan, trufflehog, wiz, envsubst, opentofu-tracing, so the fix benefits all of them.

This PR adds support for the `--retry` flag to sustain network blips and connectivity issues that we currently need to manuakly retry at the stack level