### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Fetch full history for setuptools-scm
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -76,12 +76,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Fetch full history for setuptools-scm
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Fetch full history for setuptools-scm
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     
@@ -37,7 +37,7 @@ jobs:
         twine check dist/*
     
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: distribution-files
         path: dist/
@@ -49,7 +49,7 @@ jobs:
     
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: distribution-files
         path: dist/


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `actions/checkout@v4 → actions/checkout@v7`
- `actions/download-artifact@v4 → actions/download-artifact@v8`
- `actions/setup-python@v5 → actions/setup-python@v6`
- `actions/upload-artifact@v4 → actions/upload-artifact@v7`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code
👦🏻 Reviewed by human